### PR TITLE
Fix background duplication by moving style to CSS

### DIFF
--- a/Reservas.html
+++ b/Reservas.html
@@ -5,7 +5,7 @@
         <link rel="icon" href="imagenes\lepere-micrologo.ico" type="image/x-icon ">
         <link rel="stylesheet" href="sty_resv.css">
     </head>
-    <body style="background-repeat: no-repeat; background-attachment: fixed; background-size: cover;" background="imagenes/lepere fondo claro.png" bgcolor="DARKRED" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
+    <body bgcolor="DARKRED" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
     <header>
         <nav class="navmenu">
             <div class="marca">

--- a/productos/bebidas.html
+++ b/productos/bebidas.html
@@ -6,7 +6,7 @@
         <link rel="icon" href="../imagenes/lepere-micrologo.ico" type="image/x-icon ">
         <link rel="stylesheet" href="sty_food.css">
     </head>
-    <body style="background-repeat: no-repeat; background-attachment: fixed; background-size: cover;" background="../imagenes/lepere fondo claro.png" bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
+    <body bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
     <header>
         
         <nav class="navmenu">

--- a/productos/hamburguesas.html
+++ b/productos/hamburguesas.html
@@ -6,7 +6,7 @@
         <link rel="icon" href="../imagenes/lepere-micrologo.ico" type="image/x-icon ">
         <link rel="stylesheet" href="sty_food.css">
     </head>
-    <body style="background-repeat: no-repeat; background-attachment: fixed; background-size: cover;" background="../imagenes/lepere fondo claro.png" bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
+    <body bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
     <header>
         
         <nav class="navmenu">

--- a/productos/minutas.html
+++ b/productos/minutas.html
@@ -6,7 +6,7 @@
         <link rel="icon" href="../imagenes/lepere-micrologo.ico" type="image/x-icon ">
         <link rel="stylesheet" href="sty_food.css">
     </head>
-    <body style="background-repeat: no-repeat; background-attachment: fixed; background-size: cover;" background="../imagenes/lepere fondo claro.png" bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
+    <body bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
     <header>
         
         <nav class="navmenu">

--- a/productos/pizzas.html
+++ b/productos/pizzas.html
@@ -6,7 +6,7 @@
         <link rel="icon" href="../imagenes/lepere-micrologo.ico" type="image/x-icon ">
         <link rel="stylesheet" href="sty_food.css">
     </head>
-    <body style="background-repeat: no-repeat; background-attachment: fixed; background-size: cover;" background="../imagenes/lepere fondo claro.png" bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
+    <body bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
     <header>
         
         <nav class="navmenu">

--- a/productos/productos.html
+++ b/productos/productos.html
@@ -6,7 +6,7 @@
         <link rel="icon" href="../imagenes/lepere-micrologo.ico" type="image/x-icon ">
         <link rel="stylesheet" href="sty_productos.css">
     </head>
-    <body style="background-repeat: no-repeat; background-attachment: fixed; background-size: cover;" background="../imagenes/lepere fondo claro.png" bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
+    <body bgcolor="#7e0808" text="#53170b" link="#582a0f" alink="#5e1f1f" vlink="#3b1109">
     <header>
         
         <nav class="navmenu">

--- a/productos/sty_food.css
+++ b/productos/sty_food.css
@@ -1,5 +1,10 @@
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-attachment: fixed;
+    background-color: #dda482;
+    background-image: url("../imagenes/lepere fondo claro.png");
 }
 
 .navmenu {

--- a/productos/sty_productos.css
+++ b/productos/sty_productos.css
@@ -1,5 +1,10 @@
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-attachment: fixed;
+    background-color: #dda482;
+    background-image: url("../imagenes/lepere fondo claro.png");
 }
 
 

--- a/sty.qns.css
+++ b/sty.qns.css
@@ -2,10 +2,10 @@
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background-repeat: no-repeat;
-    background-attachment: fixed; 
+    background-attachment: fixed;
     background-size: cover;
     background-color: #dda482;
-    background: url(imagenes/lepere\ fondo\ claro.png);
+    background-image: url("imagenes/lepere fondo claro.png");
 }
 .navmenu {
     display: flex;

--- a/sty_chat.css
+++ b/sty_chat.css
@@ -1,5 +1,10 @@
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-attachment: fixed;
+    background-color: #dda482;
+    background-image: url("imagenes/lepere fondo claro.png");
 }
 
 .navmenu {

--- a/sty_resv.css
+++ b/sty_resv.css
@@ -1,5 +1,10 @@
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-attachment: fixed;
+    background-color: #dda482;
+    background-image: url("imagenes/lepere fondo claro.png");
 }
 
 .navmenu {

--- a/sty_ubi.css
+++ b/sty_ubi.css
@@ -1,12 +1,12 @@
 html, body {
     font-family: 'Poppins', sans-serif;
-    background-repeat: no-repeat; 
+    background-repeat: no-repeat;
     background-attachment: fixed;
     background-size: cover;
     height: 100%;
     margin: 0;
     background-color: #dda482;
-    background: url(imagenes/lepere\ fondo\ claro.png);
+    background-image: url("imagenes/lepere fondo claro.png");
 }
 
 

--- a/styles_hmpg.css
+++ b/styles_hmpg.css
@@ -1,10 +1,10 @@
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background-repeat: no-repeat;
-    background-size: cover ;
+    background-size: cover;
     background-attachment: fixed;
     background-color: #dda482;
-    background-image: url(imagenes/lepere\ fondo\ claro.png);
+    background-image: url("imagenes/lepere fondo claro.png");
 }
 
 .tit_div {


### PR DESCRIPTION
## Summary
- update each CSS file to set the global page background with `background-image`
- remove inline `background` attributes from HTML pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687904b741548321920bb38a022a0741